### PR TITLE
2025112600 release code

### DIFF
--- a/.github/workflows/moodle-plugin-ci.yml
+++ b/.github/workflows/moodle-plugin-ci.yml
@@ -3,7 +3,13 @@ name: Moodle Plugin CI
 
 # Run this workflow every time a new commit pushed to your repository or PR
 # created.
-on: [push]
+on:
+  push:
+    paths-ignore:
+      - 'node_modules/**'
+  pull_request:
+    paths-ignore:
+      - 'node_modules/**'
 
 jobs:
   # Set the job key. The key is displayed as the job name
@@ -15,7 +21,7 @@ jobs:
     # DB services you need for testing.
     services:
       postgres:
-        image: postgres:14
+        image: postgres:15
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'
@@ -43,9 +49,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php: '8.3'
+          - php: '8.4'
             moodle-branch: 'main'
             database: 'pgsql'
+          - php: '8.4'
+            moodle-branch: 'MOODLE_501_STABLE'
+            database: 'mariadb'
+          - php: '8.3'
+            moodle-branch: 'MOODLE_500_STABLE'
+            database: 'pgsql'
+          - php: '8.3'
+            moodle-branch: 'MOODLE_405_STABLE'
+            database: 'mariadb'
           - php: '8.3'
             moodle-branch: 'MOODLE_404_STABLE'
             database: 'pgsql'

--- a/backup/moodle2/backup_panoptocourseembed_activity_task.class.php
+++ b/backup/moodle2/backup_panoptocourseembed_activity_task.class.php
@@ -31,7 +31,6 @@ require_once($CFG->dirroot . '/mod/panoptocourseembed/backup/moodle2/backup_pano
  * Provides the steps to perform one complete backup of the panoptocourseembed instance
  */
 class backup_panoptocourseembed_activity_task extends backup_activity_task {
-
     /**
      * No specific settings for this activity
      */
@@ -43,7 +42,11 @@ class backup_panoptocourseembed_activity_task extends backup_activity_task {
      */
     protected function define_my_steps() {
         $this->add_step(
-            new backup_panoptocourseembed_activity_structure_step('panoptocourseembed_structure', 'panoptocourseembed.xml'));
+            new backup_panoptocourseembed_activity_structure_step(
+                'panoptocourseembed_structure',
+                'panoptocourseembed.xml'
+            )
+        );
     }
 
     /**

--- a/backup/moodle2/backup_panoptocourseembed_stepslib.php
+++ b/backup/moodle2/backup_panoptocourseembed_stepslib.php
@@ -31,7 +31,6 @@
  * Define the complete panoptocourseembed structure for backup, with file and id annotations
  */
 class backup_panoptocourseembed_activity_structure_step extends backup_activity_structure_step {
-
     /**
      * Define standard activity structure.
      */
@@ -41,8 +40,11 @@ class backup_panoptocourseembed_activity_structure_step extends backup_activity_
         $userinfo = $this->get_setting_value('userinfo');
 
         // Define each element separated.
-        $panoptocourseembed = new backup_nested_element('panoptocourseembed', ['id'],
-            ['name', 'intro', 'introformat', 'timemodified']);
+        $panoptocourseembed = new backup_nested_element(
+            'panoptocourseembed',
+            ['id'],
+            ['name', 'intro', 'introformat', 'timemodified']
+        );
 
         // Build the tree.
         // (love this).

--- a/backup/moodle2/restore_panoptocourseembed_activity_task.class.php
+++ b/backup/moodle2/restore_panoptocourseembed_activity_task.class.php
@@ -34,7 +34,6 @@ require_once($CFG->dirroot . '/mod/panoptocourseembed/backup/moodle2/restore_pan
  *
  */
 class restore_panoptocourseembed_activity_task extends restore_activity_task {
-
     /**
      * Define (add) particular settings this activity can have
      */
@@ -48,7 +47,11 @@ class restore_panoptocourseembed_activity_task extends restore_activity_task {
     protected function define_my_steps() {
         // Panoptocourseembed only has one structure step.
         $this->add_step(
-            new restore_panoptocourseembed_activity_structure_step('panoptocourseembed_structure', 'panoptocourseembed.xml'));
+            new restore_panoptocourseembed_activity_structure_step(
+                'panoptocourseembed_structure',
+                'panoptocourseembed.xml'
+            )
+        );
     }
 
     /**

--- a/backup/moodle2/restore_panoptocourseembed_stepslib.php
+++ b/backup/moodle2/restore_panoptocourseembed_stepslib.php
@@ -32,7 +32,6 @@
  * Structure step to restore one panoptocourseembed activity
  */
 class restore_panoptocourseembed_activity_structure_step extends restore_activity_structure_step {
-
     /**
      * Define standard activity structure.
      */

--- a/classes/admin/trim_configtext.php
+++ b/classes/admin/trim_configtext.php
@@ -30,7 +30,6 @@
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class admin_setting_configtext_trimmed_courseembed extends admin_setting_configtext {
-
     /**
      * write data to storage
      *

--- a/classes/analytics/indicator/activity_base.php
+++ b/classes/analytics/indicator/activity_base.php
@@ -32,7 +32,6 @@ namespace mod_panoptocourseembed\analytics\indicator;
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 abstract class activity_base extends \core_analytics\local\indicator\community_of_inquiry_activity {
-
     /**
      * No need to fetch grades for resources.
      *

--- a/classes/analytics/indicator/cognitive_depth.php
+++ b/classes/analytics/indicator/cognitive_depth.php
@@ -32,7 +32,6 @@ namespace mod_panoptocourseembed\analytics\indicator;
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class cognitive_depth extends activity_base {
-
     /**
      * Returns the name.
      *

--- a/classes/analytics/indicator/social_breadth.php
+++ b/classes/analytics/indicator/social_breadth.php
@@ -32,7 +32,6 @@ namespace mod_panoptocourseembed\analytics\indicator;
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class social_breadth extends activity_base {
-
     /**
      * Returns the name.
      *

--- a/classes/external/external.php
+++ b/classes/external/external.php
@@ -49,7 +49,6 @@ require_once("$CFG->libdir/externallib.php");
  * @since      Moodle 3.3
  */
 class external extends external_api {
-
     /**
      * Describes the parameters for get_panoptocourseembeds_by_courses.
      *
@@ -57,10 +56,16 @@ class external extends external_api {
      * @since Moodle 3.3
      */
     public static function get_panoptocourseembeds_by_courses_parameters() {
-        return new external_function_parameters (
+        return new external_function_parameters(
             [
                 'courseids' => new external_multiple_structure(
-                    new external_value(PARAM_INT, 'Course id'), 'Array of course ids', VALUE_DEFAULT, []
+                    new external_value(
+                        PARAM_INT,
+                        'Course id'
+                    ),
+                    'Array of course ids',
+                    VALUE_DEFAULT,
+                    []
                 ),
             ]
         );
@@ -90,8 +95,7 @@ class external extends external_api {
 
         // Ensure there are courseids to loop through.
         if (!empty($params['courseids'])) {
-
-            list($courses, $warnings) = external_util::validate_courses($params['courseids'], $mycourses);
+            [$courses, $warnings] = external_util::validate_courses($params['courseids'], $mycourses);
 
             // Get the panoptocourseembeds in this course, this function checks users visibility permissions.
             // We can avoid then additional validate_context calls.
@@ -101,14 +105,16 @@ class external extends external_api {
                 // Entry to return.
                 $panoptocourseembed->name = external_format_string($panoptocourseembed->name, $context->id);
                 $options = ['noclean' => true];
-                list($panoptocourseembed->intro, $panoptocourseembed->introformat) =
-                    external_format_text($panoptocourseembed->intro,
+                [$panoptocourseembed->intro, $panoptocourseembed->introformat] =
+                    external_format_text(
+                        $panoptocourseembed->intro,
                         $panoptocourseembed->introformat,
                         $context->id,
                         'mod_panoptocourseembed',
                         'intro',
                         null,
-                        $options);
+                        $options
+                    );
                 $panoptocourseembed->introfiles =
                     external_util::get_area_files($context->id, 'mod_panoptocourseembed', 'intro', false, false);
 

--- a/classes/search/activity.php
+++ b/classes/search/activity.php
@@ -35,7 +35,6 @@ namespace mod_panoptocourseembed\search;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class activity extends \core_search\base_activity {
-
     /**
      * Returns true if this area uses file indexing.
      *

--- a/contentitem.php
+++ b/contentitem.php
@@ -60,8 +60,7 @@ if ($config->lti_ltiversion === LTI_VERSION_1P3) {
         $ltiviewerurl = new moodle_url(COURSE_EMBED_PATH);
         $resourcelinkid = sha1($ltiviewerurl->out(false) .
             '&' . $courseid .
-            '&' . $course->timecreated
-        );
+            '&' . $course->timecreated);
         $lti->id = $resourcelinkid;
     }
     if (!isset($SESSION->lti_initiatelogin_status)) {
@@ -83,8 +82,18 @@ $returnurl = new \moodle_url(COURSE_EMBED_PATH, $returnurlparams);
 
 // Prepare the request.
 $request = lti_build_content_item_selection_request(
-    $toolid, $course, $returnurl, '', '', [], [],
-    false, false, false, false, false
+    $toolid,
+    $course,
+    $returnurl,
+    '',
+    '',
+    [],
+    [],
+    false,
+    false,
+    false,
+    false,
+    false
 );
 
 // Get the launch HTML.

--- a/contentitem_return.php
+++ b/contentitem_return.php
@@ -129,7 +129,7 @@ $ltiviewerurl = new moodle_url("/mod/panoptocourseembed/view_content.php");
      * @copyright  2024 Panopto
      * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
      */
-    if (count($errors) > 0): ?>
+    if (count($errors) > 0) : ?>
         parent.document.CALLBACKS.handleError(<?php
         /**
          * JSON encode the errors array for the handleError callback.
@@ -147,7 +147,7 @@ $ltiviewerurl = new moodle_url("/mod/panoptocourseembed/view_content.php");
          * @copyright  2024 Panopto
          * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
          */
-    else: ?>
+    else : ?>
         /**
          * Create and dispatch a custom event 'sessionSelected' with session details.
          * This event should close the Panopto popup and pass the new content URL to the existing iframe.

--- a/index.php
+++ b/index.php
@@ -33,5 +33,3 @@ require_login($id);
 $PAGE->set_url('/mod/panoptocourseembed/index.php', ['id' => $id]);
 
 redirect("$CFG->wwwroot/course/view.php?id=$id");
-
-

--- a/lib.php
+++ b/lib.php
@@ -52,7 +52,11 @@ function panoptocourseembed_add_instance($panoptocourseembed) {
 
     $completiontimeexpected = !empty($panoptocourseembed->completionexpected) ? $panoptocourseembed->completionexpected : null;
     \core_completion\api::update_completion_date_event(
-        $panoptocourseembed->coursemodule, 'panoptocourseembed', $id, $completiontimeexpected);
+        $panoptocourseembed->coursemodule,
+        'panoptocourseembed',
+        $id,
+        $completiontimeexpected
+    );
 
     return $id;
 }
@@ -80,7 +84,11 @@ function panoptocourseembed_update_instance($panoptocourseembed, $mform) {
 
     $completiontimeexpected = !empty($panoptocourseembed->completionexpected) ? $panoptocourseembed->completionexpected : null;
     \core_completion\api::update_completion_date_event(
-        $panoptocourseembed->coursemodule, 'panoptocourseembed', $panoptocourseembed->id, $completiontimeexpected);
+        $panoptocourseembed->coursemodule,
+        'panoptocourseembed',
+        $panoptocourseembed->id,
+        $completiontimeexpected
+    );
 
     return $DB->update_record("panoptocourseembed", $panoptocourseembed);
 }
@@ -124,8 +132,13 @@ function panoptocourseembed_delete_instance($id) {
 function panoptocourseembed_get_coursemodule_info($coursemodule) {
     global $DB;
 
-    if ($panoptocourseembed = $DB->get_record('panoptocourseembed',
-        ['id' => $coursemodule->instance], 'id, name, intro, introformat')) {
+    if (
+        $panoptocourseembed = $DB->get_record(
+            'panoptocourseembed',
+            ['id' => $coursemodule->instance],
+            'id, name, intro, introformat'
+        )
+    ) {
         if (empty($panoptocourseembed->name)) {
             // Panoptocourseembed name missing, fix it.
             $panoptocourseembed->name = "panoptocourseembed{$panoptocourseembed->id}";
@@ -168,7 +181,7 @@ function panoptocourseembed_reset_userdata($data) {
  * @return bool|null True if module supports feature, false if not, null if doesn't know
  */
 function panoptocourseembed_supports($feature) {
-    switch($feature) {
+    switch ($feature) {
         case FEATURE_IDNUMBER:
             return true;
         case FEATURE_GROUPS:
@@ -219,9 +232,11 @@ function panoptocourseembed_check_updates_since(cm_info $cm, $from, $filter = []
  * @param int $userid User id to use for all capability checks, etc. Set to 0 for current user (default).
  * @return \core_calendar\local\event\entities\action_interface|null
  */
-function mod_panoptocourseembed_core_calendar_provide_event_action(calendar_event $event,
-                                                      \core_calendar\action_factory $factory,
-                                                      int $userid = 0) {
+function mod_panoptocourseembed_core_calendar_provide_event_action(
+    calendar_event $event,
+    \core_calendar\action_factory $factory,
+    int $userid = 0
+) {
     $cm = get_fast_modinfo($event->courseid, $userid)->instances['panoptocourseembed'][$event->instance];
 
     if (!$cm->uservisible) {

--- a/mod_form.php
+++ b/mod_form.php
@@ -25,8 +25,10 @@
 defined('MOODLE_INTERNAL') || die;
 
 require_once(dirname(dirname(dirname(__FILE__))) . '/config.php');
-require_once($CFG->dirroot.'/course/moodleform_mod.php');
+require_once($CFG->dirroot . '/course/moodleform_mod.php');
 require_once($CFG->dirroot . '/blocks/panopto/lib/lti/panoptoblock_lti_utility.php');
+require_once($CFG->dirroot . '/blocks/panopto/lib/panopto_data.php');
+
 
 require_login();
 
@@ -38,7 +40,6 @@ require_login();
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class mod_panoptocourseembed_mod_form extends moodleform_mod {
-
     /**
      * Definition function for the form.
      */
@@ -58,6 +59,10 @@ class mod_panoptocourseembed_mod_form extends moodleform_mod {
             return;
         }
 
+        // If configured we will provision the course for lti.
+        \panopto_data::provision_course_for_lti($COURSE->id);
+
+        // Start loading the form.
         $mform = $this->_form;
         $mform->addElement('header', 'generalhdr', get_string('general'));
         $cimurlparams = ['courseid' => $COURSE->id];

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -32,7 +32,6 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class mod_panoptocourseembed_generator extends testing_module_generator {
-
     /**
      * Definition function for create instance.
      *

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -33,7 +33,6 @@ namespace mod_panoptocourseembed;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 final class lib_test extends \advanced_testcase {
-
     /**
      * Set up.
      */
@@ -54,8 +53,11 @@ final class lib_test extends \advanced_testcase {
         $panoptocourseembed = $this->getDataGenerator()->create_module('panoptocourseembed', ['course' => $course->id]);
 
         // Create a calendar event.
-        $event = $this->create_action_event($course->id, $panoptocourseembed->id,
-            \core_completion\api::COMPLETION_EVENT_TYPE_DATE_COMPLETION_EXPECTED);
+        $event = $this->create_action_event(
+            $course->id,
+            $panoptocourseembed->id,
+            \core_completion\api::COMPLETION_EVENT_TYPE_DATE_COMPLETION_EXPECTED
+        );
 
         // Create an action factory.
         $factory = new \core_calendar\action_factory();
@@ -83,8 +85,11 @@ final class lib_test extends \advanced_testcase {
         $panoptocourseembed = $this->getDataGenerator()->create_module('panoptocourseembed', ['course' => $course->id]);
 
         // Create a calendar event.
-        $event = $this->create_action_event($course->id, $panoptocourseembed->id,
-                \core_completion\api::COMPLETION_EVENT_TYPE_DATE_COMPLETION_EXPECTED);
+        $event = $this->create_action_event(
+            $course->id,
+            $panoptocourseembed->id,
+            \core_completion\api::COMPLETION_EVENT_TYPE_DATE_COMPLETION_EXPECTED
+        );
 
         // Now log out.
         $CFG->forcelogin = true; // We don't want to be logged in as guest, as guest users might still have some capabilities.
@@ -113,8 +118,11 @@ final class lib_test extends \advanced_testcase {
         $student = $this->getDataGenerator()->create_and_enrol($course, 'student');
 
         // Create a calendar event.
-        $event = $this->create_action_event($course->id, $panoptocourseembed->id,
-                \core_completion\api::COMPLETION_EVENT_TYPE_DATE_COMPLETION_EXPECTED);
+        $event = $this->create_action_event(
+            $course->id,
+            $panoptocourseembed->id,
+            \core_completion\api::COMPLETION_EVENT_TYPE_DATE_COMPLETION_EXPECTED
+        );
 
         // Set sections 0 as hidden.
         set_section_visible($course->id, 0, 0);
@@ -144,8 +152,11 @@ final class lib_test extends \advanced_testcase {
         $student = $this->getDataGenerator()->create_and_enrol($course, 'student');
 
         // Create a calendar event.
-        $event = $this->create_action_event($course->id, $panoptocourseembed->id,
-            \core_completion\api::COMPLETION_EVENT_TYPE_DATE_COMPLETION_EXPECTED);
+        $event = $this->create_action_event(
+            $course->id,
+            $panoptocourseembed->id,
+            \core_completion\api::COMPLETION_EVENT_TYPE_DATE_COMPLETION_EXPECTED
+        );
 
         // Now, log out.
         $CFG->forcelogin = true; // We don't want to be logged in as guest, as guest users might still have some capabilities.
@@ -176,20 +187,25 @@ final class lib_test extends \advanced_testcase {
 
         // Create the activity.
         $course = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
-        $panoptocourseembed = $this->getDataGenerator()->create_module('panoptocourseembed',
+        $panoptocourseembed = $this->getDataGenerator()->create_module(
+            'panoptocourseembed',
             ['course' => $course->id],
             [
                 'completion' => 2,
                 'completionview' => 1,
                 'completionexpected' => time() + DAYSECS,
-            ]);
+            ]
+        );
 
         // Get some additional data.
         $cm = get_coursemodule_from_instance('panoptocourseembed', $panoptocourseembed->id);
 
         // Create a calendar event.
-        $event = $this->create_action_event($course->id, $panoptocourseembed->id,
-            \core_completion\api::COMPLETION_EVENT_TYPE_DATE_COMPLETION_EXPECTED);
+        $event = $this->create_action_event(
+            $course->id,
+            $panoptocourseembed->id,
+            \core_completion\api::COMPLETION_EVENT_TYPE_DATE_COMPLETION_EXPECTED
+        );
 
         // Mark the activity as completed.
         $completion = new \completion_info($course);
@@ -216,13 +232,15 @@ final class lib_test extends \advanced_testcase {
 
         // Create the activity.
         $course = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
-        $panoptocourseembed = $this->getDataGenerator()->create_module('panoptocourseembed',
+        $panoptocourseembed = $this->getDataGenerator()->create_module(
+            'panoptocourseembed',
             ['course' => $course->id],
             [
                 'completion' => 2,
                 'completionview' => 1,
                 'completionexpected' => time() + DAYSECS,
-            ]);
+            ]
+        );
 
         // Enrol a student in the course.
         $student = $this->getDataGenerator()->create_and_enrol($course, 'student');
@@ -231,8 +249,11 @@ final class lib_test extends \advanced_testcase {
         $cm = get_coursemodule_from_instance('panoptocourseembed', $panoptocourseembed->id);
 
         // Create a calendar event.
-        $event = $this->create_action_event($course->id, $panoptocourseembed->id,
-                \core_completion\api::COMPLETION_EVENT_TYPE_DATE_COMPLETION_EXPECTED);
+        $event = $this->create_action_event(
+            $course->id,
+            $panoptocourseembed->id,
+            \core_completion\api::COMPLETION_EVENT_TYPE_DATE_COMPLETION_EXPECTED
+        );
 
         // Mark the activity as completed for the student.
         $completion = new \completion_info($course);

--- a/tests/mod_panoptocourseembed_external_testcase.php
+++ b/tests/mod_panoptocourseembed_external_testcase.php
@@ -40,7 +40,6 @@ require_once($CFG->dirroot . '/webservice/tests/helpers.php');
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class mod_panoptocourseembed_external_testcase extends externallib_advanced_testcase {
-
     /**
      * Test get panoptocourseembeds by courses.
      */

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 // The current module version (Date: YYYYMMDDXX).
-$plugin->version = 2024120600;
+$plugin->version = 2025112600;
 
 // Requires this Moodle version 4.1.0.
 $plugin->requires = 2022112800;
@@ -33,7 +33,7 @@ $plugin->requires = 2022112800;
 // Full name of the plugin (used for diagnostics).
 $plugin->component = 'mod_panoptocourseembed';
 $plugin->cron      = 0;
-$plugin->maturity  = MATURITY_BETA;
+$plugin->maturity = MATURITY_STABLE;
 
 // Dependencies.
 $plugin->dependencies = [

--- a/view.php
+++ b/view.php
@@ -40,13 +40,12 @@ if ($id) {
     if (! $panoptocourseembed = $DB->get_record("panoptocourseembed", ["id" => $cm->instance])) {
         throw new moodle_exception('invalidcoursemodule');
     }
-
 } else {
     $PAGE->set_url('/mod/panoptocourseembed/index.php', ['panoptoid' => $panoptoid]);
     if (! $panoptocourseembed = $DB->get_record("panoptocourseembed", ["id" => $panoptoid])) {
         throw new moodle_exception('invalidcoursemodule');
     }
-    if (! $course = $DB->get_record("course", ["id" => $panoptocourseembed->course]) ) {
+    if (! $course = $DB->get_record("course", ["id" => $panoptocourseembed->course])) {
         throw new moodle_exception('coursemisconf');
     }
     if (! $cm = get_coursemodule_from_instance("panoptocourseembed", $panoptocourseembed->id, $course->id)) {
@@ -57,5 +56,3 @@ if ($id) {
 require_login($course, true, $cm);
 
 redirect("$CFG->wwwroot/course/view.php?id=$course->id");
-
-

--- a/view_content.php
+++ b/view_content.php
@@ -52,9 +52,9 @@ require_login($course, true);
 if (empty($resourcelinkid)) {
     $pageurl = new moodle_url("/mod/panoptocourseembed/view_content.php");
     $resourcelinkid = sha1(
-            $pageurl->out(false) . '&' . $course->id
-                . '&' . $course->startdate
-        );
+        $pageurl->out(false) . '&' . $course->id .
+        '&' . $course->startdate
+    );
 }
 
 $contenturl = urldecode(optional_param('contenturl', '', PARAM_URL));
@@ -96,7 +96,8 @@ if ($customdata) {
 $config = lti_get_type_type_config($toolid);
 if ($config->lti_ltiversion === LTI_VERSION_1P3) {
     if (!isset($SESSION->lti_initiatelogin_status)) {
-        echo lti_initiate_login($courseid,
+        echo lti_initiate_login(
+            $courseid,
             "mod_panoptocourseembed,'',{$toolid},{$resourcelinkid},{$contenturl},{$customdata}",
             $lti,
             $config


### PR DESCRIPTION
This is the current stable release version of the Panopto Course Embed tool for Moodle. Once installed, this plugin will add a new Panopto Course Embed Activity to the Activity or Resources section of a course. The new activity allows instructors to directly embed Panopto videos or a Panopto course folder in their course, without the need to use either the Atto or TinyMCE plugins.

This version supports (a) Moodle 4.1, 4.2, 4.3, 4.4, 4.5, 5.0, 5.1 running with PHP 7.4, 8.0, 8.1, 8.2 and (b) Panopto version 10.6.1 or later.

This plugin requires the Panopto Moodle Block plugin version 2022122000 or higher.

Below is the list of updates from the previous release (2024120600).

✨ New Features & Compatibility
- Moodle 5.0 & 5.1 Support: The Course Embed activity has been updated to support the core API changes in Moodle 5.0 and 5.1, ensuring instructors can continue to embed content seamlessly in the newest LMS versions

🛠️ Bug Fixes
- LTI Folder Provisioning & Category Structure: Resolved an issue where Panopto folders provisioned via the LTI tool were occasionally created outside of the expected Moodle category hierarchy. The provisioning logic now correctly identifies the Moodle course's category and ensures the Panopto folder is placed within the corresponding structure on the server
