### PR TITLE
2026060300 release code

### DIFF
--- a/.github/workflows/moodle-plugin-ci.yml
+++ b/.github/workflows/moodle-plugin-ci.yml
@@ -21,7 +21,7 @@ jobs:
     # DB services you need for testing.
     services:
       postgres:
-        image: postgres:15
+        image: postgres:16
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'
@@ -30,7 +30,7 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
 
       mariadb:
-        image: mariadb:10
+        image: mariadb:10.11
         env:
           MYSQL_USER: 'root'
           MYSQL_ALLOW_EMPTY_PASSWORD: "true"
@@ -50,10 +50,13 @@ jobs:
       matrix:
         include:
           - php: '8.4'
-            moodle-branch: 'main'
-            database: 'pgsql'
+            moodle-branch: 'MOODLE_501_STABLE'
+            database: 'mariadb'
           - php: '8.4'
             moodle-branch: 'MOODLE_501_STABLE'
+            database: 'pgsql'
+          - php: '8.3'
+            moodle-branch: 'MOODLE_500_STABLE'
             database: 'mariadb'
           - php: '8.3'
             moodle-branch: 'MOODLE_500_STABLE'
@@ -62,17 +65,8 @@ jobs:
             moodle-branch: 'MOODLE_405_STABLE'
             database: 'mariadb'
           - php: '8.3'
-            moodle-branch: 'MOODLE_404_STABLE'
+            moodle-branch: 'MOODLE_405_STABLE'
             database: 'pgsql'
-          - php: '8.2'
-            moodle-branch: 'MOODLE_403_STABLE'
-            database: 'mariadb'
-          - php: '8.1'
-            moodle-branch: 'MOODLE_402_STABLE'
-            database: 'pgsql'
-          - php: '8.1'
-            moodle-branch: 'MOODLE_401_STABLE'
-            database: 'mariadb'
 
     steps:
       # Check out this repository code in ./plugin directory

--- a/contentitem.php
+++ b/contentitem.php
@@ -36,7 +36,6 @@ const COURSE_EMBED_PATH = '/mod/panoptocourseembed/contentitem_return.php';
 
 // Check access and capabilities.
 $course = get_course($courseid);
-require_login($course);
 
 $toolid = \panoptoblock_lti_utility::get_course_tool_id($courseid, 'panopto_course_embed_tool');
 
@@ -70,6 +69,8 @@ if ($config->lti_ltiversion === LTI_VERSION_1P3) {
         unset($SESSION->lti_initiatelogin_status);
     }
 }
+
+require_login($course);
 
 // Set the return URL. We send the launch container along to help us avoid
 // frames-within-frames when the user returns.

--- a/contentitem_return.php
+++ b/contentitem_return.php
@@ -24,6 +24,7 @@
  */
 
 require_once(dirname(dirname(dirname(__FILE__))) . '/config.php');
+require_once(dirname(__FILE__) . '/lib.php');
 require_once($CFG->dirroot . '/blocks/panopto/lib/lti/panoptoblock_lti_utility.php');
 require_once($CFG->dirroot . '/blocks/panopto/lib/panopto_data.php');
 require_once(dirname(dirname(dirname(__FILE__))) . '/mod/lti/lib.php');
@@ -33,7 +34,7 @@ $courseid = required_param('course', PARAM_INT);
 $id       = required_param('id', PARAM_INT);
 $jwt      = optional_param('JWT', '', PARAM_RAW);
 
-require_login($courseid);
+panoptocourseembed_require_login_or_repost($courseid);
 
 $context = context_course::instance($courseid);
 

--- a/lib.php
+++ b/lib.php
@@ -259,3 +259,35 @@ function mod_panoptocourseembed_core_calendar_provide_event_action(
         true
     );
 }
+
+/**
+ * Ensure the user is logged in, or perform a cross-site repost if cookies were blocked.
+ *
+ * @param int $courseid Course to require login for after repost succeeds.
+ */
+function panoptocourseembed_require_login_or_repost(int $courseid): void {
+    global $PAGE, $_POST;
+
+    $context = context_course::instance($courseid);
+    $PAGE->set_pagelayout('popup');
+    $PAGE->set_context($context);
+
+    if (method_exists('panoptoblock_lti_utility', 'require_login_or_repost')) {
+        panoptoblock_lti_utility::require_login_or_repost($courseid, $context);
+        return;
+    }
+
+    if (!empty($_POST['repost'])) {
+        unset($_POST['repost']);
+    } else if (!isloggedin()) {
+        header_remove('Set-Cookie');
+        $output = $PAGE->get_renderer('mod_lti');
+        $page = new \mod_lti\output\repost_crosssite_page($_SERVER['REQUEST_URI'], $_POST);
+        echo $output->header();
+        echo $output->render($page);
+        echo $output->footer();
+        exit;
+    }
+
+    require_login($courseid);
+}

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 // The current module version (Date: YYYYMMDDXX).
-$plugin->version = 2025112600;
+$plugin->version = 2026060300;
 
 // Requires this Moodle version 4.1.0.
 $plugin->requires = 2022112800;

--- a/view_content.php
+++ b/view_content.php
@@ -46,7 +46,6 @@ if (!empty($_SERVER['HTTP_REFERER']) && (strpos($_SERVER['HTTP_REFERER'], "/cour
 $course = $DB->get_record('course', ['id' => $courseid], '*', MUST_EXIST);
 $context = context_course::instance($courseid);
 $PAGE->set_context($context);
-require_login($course, true);
 
 // Not quite unique, but better than 99999 for old embeds.
 if (empty($resourcelinkid)) {
@@ -59,9 +58,6 @@ if (empty($resourcelinkid)) {
 
 $contenturl = urldecode(optional_param('contenturl', '', PARAM_URL));
 $customdata = urldecode(optional_param('custom', '', PARAM_RAW_TRIMMED));
-
-require_login($course);
-require_capability('mod/lti:view', $context);
 
 // Get a matching LTI tool for the course.
 $toolid = \panoptoblock_lti_utility::get_course_tool_id($courseid, 'panopto_course_embed_tool');
@@ -107,5 +103,8 @@ if ($config->lti_ltiversion === LTI_VERSION_1P3) {
         unset($SESSION->lti_initiatelogin_status);
     }
 }
+
+require_login($course, true);
+require_capability('mod/lti:view', $context);
 
 echo \panoptoblock_lti_utility::launch_tool($lti);


### PR DESCRIPTION
This is the stable release of the Panopto Course Embed tool for Moodle. Once installed, this plugin will add a new Panopto Course Embed Activity to the Activity or Resources section of a course. The new activity allows instructors to directly embed Panopto videos or a Panopto course folder in their course, without the need to use either the Atto or TinyMCE plugins.

This version supports (a) Moodle 4.5, 5.0, 5.1 running with PHP 7.4, 8.0, 8.1, 8.2 and (b) Panopto version 10.6.1 or later.

This plugin requires the Panopto Moodle Block plugin version 2022122000 or higher.

Below is the list of updates from the previous release (2025112600).

🛠️ Bug Fixes
- LTI Integration: Resolved a login loop that occurred when selecting Panopto content via LTI across different domains. Implemented a cross-site repost handshake to ensure Moodle session cookies are correctly transmitted under modern SameSite=Lax policies.